### PR TITLE
Add support for dotenv files which are not in git

### DIFF
--- a/lib/oops/tasks.rb
+++ b/lib/oops/tasks.rb
@@ -10,6 +10,7 @@ namespace :oops do
     sh %{git archive --format zip --output build/#{file_path} HEAD}
 
     sh %{zip -r -g build/#{file_path} public/}
+    sh %{zip -r -g build/#{file_path} .env*}
     sh %{zip build/#{file_path} -d .gitignore}
 
     sh %{rm -rf public/assets}

--- a/lib/oops/version.rb
+++ b/lib/oops/version.rb
@@ -1,3 +1,3 @@
 module Oops
-  VERSION = "0.0.2"
+  VERSION = "0.0.3"
 end


### PR DESCRIPTION
Previously any dotenv files which are not in git would not
be included in the packaged zip.
