### PR TITLE
Bump the minimum aws-sdk and bundler version to newer ones

### DIFF
--- a/lib/oops/version.rb
+++ b/lib/oops/version.rb
@@ -1,3 +1,3 @@
 module Oops
-  VERSION = "0.2.0"
+  VERSION = "0.3.0"
 end

--- a/oops.gemspec
+++ b/oops.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "aws-sdk", "~> 2.0"
+  spec.add_dependency "aws-sdk", "~> 3.0"
   spec.add_development_dependency "bundler", "~> 1.3"
   spec.add_development_dependency "rake"
 end

--- a/oops.gemspec
+++ b/oops.gemspec
@@ -19,6 +19,6 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency "aws-sdk", "~> 3.0"
-  spec.add_development_dependency "bundler", "~> 1.3"
+  spec.add_development_dependency "bundler", "~> 2"
   spec.add_development_dependency "rake"
 end


### PR DESCRIPTION
`aws-sdk` and `bundler` versions are deprecated.

This PR bumps the required version to ensure we keep up with the supported ones.